### PR TITLE
Remove an article 'a' which is not needed in Japanese

### DIFF
--- a/guides/source/ja/action_view_overview.md
+++ b/guides/source/ja/action_view_overview.md
@@ -796,7 +796,7 @@ third:
 ここで扱うフォームヘルパーの中心となるのは`form_for`メソッドです。このメソッドはモデルのインスタンスからフォームを作成することができます。たとえば、以下のようにPersonというモデルがあり、このモデルをもとにしてインスタンスを1つ作成するとします。
 
 ```html+erb
-# メモ: a @person変数はコントローラ側で設定済みであるとする (@person = Person.newなど)
+# メモ: @person変数はコントローラ側で設定済みであるとする (@person = Person.newなど)
 <%= form_for @person, url: { action: "create" } do |f| %>
   <%= f.text_field :first_name %>
   <%= f.text_field :last_name %>


### PR DESCRIPTION
Japanese doesn't need an article 'a' here.


This is the original sentence in [rails/rails](https://github.com/rails/rails/blob/master/guides/source/action_view_overview.md#formhelper). 
```
# Note: a @person variable will have been created in the controller (e.g. @person = Person.new)
<%= form_for @person, url: { action: "create" } do \|f\| %>
  <%= f.text_field :first_name %>
  <%= f.text_field :last_name %>  
  <%= submit_tag 'Create' %>
<% end %>
```



<!--
railsguides.jp では更新箇所のみを効率的に翻訳するため、rails/rails や edgeguides との差分翻訳は基本的にマージしていません。差分翻訳を行う場合は https://github.com/yasslab/railsguides.jp/tree/master/guides/source にあるファイルまたはコミットとの差分を更新していただけると嬉しいです!

🆗 マージ可能なPR例:
https://github.com/yasslab/railsguides.jp/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

🆖 マージしづらいPR例:
https://github.com/rails/rails/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

更新箇所のみを効率的に翻訳する方法については https://github.com/yasslab/railsguides.jp/pull/815 をご参照ください (＞人＜ )✨
-->

